### PR TITLE
質問削除機能の実装

### DIFF
--- a/src/backend/app/Http/Controllers/QuestionController.php
+++ b/src/backend/app/Http/Controllers/QuestionController.php
@@ -44,4 +44,11 @@ class QuestionController extends Controller
 
         return response()->json(new QuestionResource($question), 200);
     }
+
+    public function destroy(Question $question): JsonResponse
+    {
+        $question->delete();
+
+        return response()->json(200);
+    }
 }

--- a/src/backend/database/migrations/2024_10_05_145055_create_category_question_table.php
+++ b/src/backend/database/migrations/2024_10_05_145055_create_category_question_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('category_question', function (Blueprint $table) {
             $table->foreignId('category_id')->constrained('categories', 'id');
-            $table->foreignId('question_id')->constrained('questions', 'id');
+            $table->foreignId('question_id')->constrained('questions', 'id')->cascadeOnDelete();
             $table->unique(['category_id', 'question_id']);
         });
     }

--- a/src/backend/database/migrations/2024_10_06_153726_create_comments_table.php
+++ b/src/backend/database/migrations/2024_10_06_153726_create_comments_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('comments', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('question_id')->constrained('questions', 'id');
+            $table->foreignId('question_id')->constrained('questions', 'id')->cascadeOnDelete();
             $table->text('content');
             $table->timestamps();
         });

--- a/src/backend/database/migrations/2024_10_07_175032_create_replies_table.php
+++ b/src/backend/database/migrations/2024_10_07_175032_create_replies_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('replies', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('comment_id')->constrained('comments', 'id');
+            $table->foreignId('comment_id')->constrained('comments', 'id')->cascadeOnDelete();
             $table->text('content');
             $table->timestamps();
         });

--- a/src/backend/routes/api.php
+++ b/src/backend/routes/api.php
@@ -13,5 +13,6 @@ Route::get('/user', function (Request $request) {
 Route::get('/questions', [QuestionController::class, 'index']);
 Route::post('/questions', [QuestionController::class, 'store']);
 Route::patch('/questions/{question}', [QuestionController::class, 'update']);
+Route::delete('/questions/{question}', [QuestionController::class, 'destroy']);
 Route::post('/{question}/comments', [CommentController::class, 'store']);
 Route::post('/{comment}/replies', [ReplyController::class, 'store']);


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
close #53 

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 質問の削除機能を実装
- 質問に紐付いたコメントの物理削除
- コメントに紐付いたリプライの物理削除
- 質問に紐付いているカテゴリーの物理削除

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
なし

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- comments テーブルの question_id カラムに cascadeOnDelete() を追加。
- replies テーブルの comment_id カラムに cascadeOnDelete() を追加。

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- 質問を削除するとデータが物理削除されるか？
- 質問に紐づくコメントデータが物理削除されるか？
- コメントに紐づくリプライデータが物理削除されるか？
- 質問に紐付くカテゴリーの中間データが物理削除されるか？